### PR TITLE
Torna branch build do Semaphore dinâmico

### DIFF
--- a/apache-woocommerce-ci/Dockerfile
+++ b/apache-woocommerce-ci/Dockerfile
@@ -158,7 +158,7 @@ RUN { \
     } > /var/www/html/.htaccess
 
 RUN chmod -R 777 *
-RUN git clone -b develop https://github.com/vindi/vindi-woocommerce-subscriptions.git wp-content/plugins/vindi-woocommerce-subscriptions
+RUN git clone -b "${SEMAPHORE_GIT_BRANCH}" https://github.com/vindi/vindi-woocommerce-subscriptions.git wp-content/plugins/vindi-woocommerce-subscriptions
 
 WORKDIR /var/www/html/wp-content/plugins/vindi-woocommerce-subscriptions
 RUN composer install


### PR DESCRIPTION
## Motivação
Atualmente a _branch_ utilizada para execução da _build_ de testes no [Semaphore]() está setada estáticamente como `develop`.
Isso faz com que as alterações realizadas na _branch_ atual não sejam testadas.
## Solução proposta
Utilizar a variável de ambiente `SEMAPHORE_GIT_BRANCH` para selecionar a _branch_ correta ao fazer o build.